### PR TITLE
added utils to handle dtconversions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,11 @@ History
 
 0.2.0 (2018-07-03)
 ------------------
-* Built adapter module and related functionality 
+* Built adapter module and related functionality
 * removed calc_factory API (possibly will be re-included in a later build)
-* created the CollectionBuilder class 
+* created the CollectionBuilder class
+
+
+0.2.1 (2018-07-12)
+------------------
+* patched issue relating to datetime/datestrings not being parsed by collections

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ binx
         :target: https://binx.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-:version: 0.2.0
+:version: 0.2.1
 
 
 Interfaces for an in-memory datastore and calc framework using marshmallow + pandas

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ This can help you quickly scale up your scripts and create uniformity between yo
 binx provides:
 
 * A declarative style in memory datastore (collections)
-* interfaces and base classes for processing and scaling up your calc scripts (calc, factory)
+* An Adapter API that helps model/manage relationships and data transformations between collections (adapter)
 * consistent API for moving your data between json, py-objs, and pandas dataframes
 
 Coming Soon

--- a/binx/__init__.py
+++ b/binx/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """bsnacks000"""
 __email__ = 'bsnacks000@gmail.com'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 from .collection import BaseCollection, BaseSerializer, InternalObject
 

--- a/binx/collection.py
+++ b/binx/collection.py
@@ -75,6 +75,11 @@ class BaseSerializer(Schema):
             if isinstance(field, fields.DateTime):
                 if field.dateformat is not None:
                     dateformat_fields[col] = field.dateformat
+            elif isinstance(field, fields.Date):
+                if hasattr(field, 'dateformat'):
+                    dateformat_fields[col] = field.dateformat
+                else:
+                    dateformat_fields[col] = '%Y-%m-%d' # we set this as a default for datetime.date based objects
         return dateformat_fields
 
 
@@ -173,12 +178,6 @@ class BaseCollection(AbstractCollection):
     def __init__(self):
         self._data = []
         self._serializer = self.serializer_class(internal=self.__class__.internal_class, strict=True)
-        self._return_self()
-
-    def _return_self(self):
-        """ allows chaining instantiation with load
-        """
-        return self
 
 
     @classmethod

--- a/binx/collection.py
+++ b/binx/collection.py
@@ -37,7 +37,7 @@ class BaseSerializer(Schema):
     It also provides a mapping of numpy dtypes to a select amount of marshmallow field name which helps optimize
     memory in the to_dataframe object
     """
-    
+
     registered_colls = set()
 
     numpy_map = {
@@ -56,13 +56,24 @@ class BaseSerializer(Schema):
 
 
     def __init__(self, *args, **kwargs):
-
+        self.dateformat_fields = self._set_dateformat_fields()
         if 'internal' in kwargs:
             self._InternalClass = kwargs.pop('internal')
         else:
             raise InternalNotDefinedError('An InternalObject class must be instantiated with this Collection')
 
         super(Schema, self).__init__(*args, **kwargs)
+
+
+    def _set_dateformat_fields(self):
+        """ builds a mapping of date formatted column names to string formats for Collection.load_data
+        """
+        dateformat_fields = {}
+        for col,field in self.fields.items():
+            if isinstance(field, fields.Date) or isinstance(field, fields.DateTime):
+                dateformat_fields[col] = field.dateformat
+        return dateformat_fields
+
 
 
     @post_load
@@ -163,7 +174,7 @@ class BaseCollection(AbstractCollection):
         self._return_self()
 
     def _return_self(self):
-        """ allows chaining instantiation with load 
+        """ allows chaining instantiation with load
         """
         return self
 
@@ -254,7 +265,6 @@ class BaseCollection(AbstractCollection):
             current_adapter = adapter_class() # for each adapter class we push the input_collection and a context
             adapter_output = current_adapter(current_input, **current_context) # adapt data to the next type of collection
             current_context = {**current_context, **adapter_output.context} # NOTE this is will fail on py3.4
-            #print('current_context', current_context)
             current_input = adapter_output.collection
 
         adapter_output._context = current_context
@@ -278,15 +288,41 @@ class BaseCollection(AbstractCollection):
         return df
 
 
+    def _clean_dataframe(self, df):
+        """ cleans and converts formats on a dataframe
+        """
+        formatfields = self.serializer.dateformat_fields
+
+        util = DataFrameDtypeConversion()
+        df = util.df_nan_to_none(df)
+        if len(formatfields) > 0:
+            date_col_mapping = self.serializer.dateformat_fields
+            df = util.date_to_string(formatfields, df)
+
+        records = df.to_dict('records')
+        return records
+
+    def _clean_records(self, records):
+        formatfields = self.serializer.dateformat_fields
+
+        util = RecordUtils()
+        #TODO should check nans here but need a faster algo
+
+        if len(formatfields) > 0:
+            records = util.date_to_string(formatfields, records)
+
+        return records
+
+
     def load_data(self, records):
         """default implementation. Defaults to handling lists of python-dicts (records).
         #TODO -- create a drop_duplicates option and use pandas to drop the dupes
         """
         try:
             if isinstance(records, pd.DataFrame):
-                util = DataFrameDtypeConversion()
-                records = util.df_nan_to_none(records)
-                records = records.to_dict('records')
+                records = self._clean_dataframe(records)
+            else:
+                records = self._clean_records(records)
 
             # append to the data dictionary
             # NOTE changing this to handle tuples in marsh 2.x
@@ -305,6 +341,7 @@ class BaseCollection(AbstractCollection):
         except Exception as err:
             l.error(err) #memoized property until it changes
             raise CollectionLoadError('An error occurred while loading and validating records') from err
+
 
     @classmethod
     def adapt(cls, input_collection, **adapter_context):
@@ -331,14 +368,12 @@ class BaseCollection(AbstractCollection):
                 input_collection.__class__.__name__, cls.__name__))
 
 
-
     def to_dataframe(self):
         """ returns a dataframe representation of the object. This wraps the data property in a
         pd.DataFrame
         converts any columns that can be converted to datetime
         """
-        df = self._dataframe_with_dtypes(self.data)
-        return df
+        return self._dataframe_with_dtypes(self.data)
 
 
     def to_json(self):

--- a/binx/collection.py
+++ b/binx/collection.py
@@ -56,7 +56,7 @@ class BaseSerializer(Schema):
 
 
     def __init__(self, *args, **kwargs):
-        self.dateformat_fields = self._set_dateformat_fields()
+
         if 'internal' in kwargs:
             self._InternalClass = kwargs.pop('internal')
         else:
@@ -64,16 +64,18 @@ class BaseSerializer(Schema):
 
         super(Schema, self).__init__(*args, **kwargs)
 
+        self.dateformat_fields = self._set_dateformat_fields()
+
 
     def _set_dateformat_fields(self):
         """ builds a mapping of date formatted column names to string formats for Collection.load_data
         """
         dateformat_fields = {}
         for col,field in self.fields.items():
-            if isinstance(field, fields.Date) or isinstance(field, fields.DateTime):
-                dateformat_fields[col] = field.dateformat
+            if isinstance(field, fields.DateTime):
+                if field.dateformat is not None:
+                    dateformat_fields[col] = field.dateformat
         return dateformat_fields
-
 
 
     @post_load
@@ -330,7 +332,6 @@ class BaseCollection(AbstractCollection):
             self._data += valid
 
         except TypeError as err:
-            l.error(err)
             raise CollectionLoadError('A Serializer must be instantiated with valid fields') from err
 
         except ValidationError as err:
@@ -339,7 +340,6 @@ class BaseCollection(AbstractCollection):
             raise CollectionValidationError('A ValidationError occurred while trying to load {}'.format(self.__class__.__name__)) from err
 
         except Exception as err:
-            l.error(err) #memoized property until it changes
             raise CollectionLoadError('An error occurred while loading and validating records') from err
 
 

--- a/binx/utils.py
+++ b/binx/utils.py
@@ -77,11 +77,13 @@ class RecordUtils(object):
         """converts datetime or date objects to strings
         """
         for rec in records:
-            for col,dformat in col_mapping:
-                if isinstance(rec[col], datetime.date)
+            for col,dformat in col_mapping.items():
+                if isinstance(rec[col], datetime.datetime):
                     rec[col] = datetime.datetime.strftime(dformat)
-                else:
+                elif isinstance(rec[col], datetime.date):
                     rec[col] = datetime.date.strftime(dformat)
+                else: # this means its already in a non-dt format
+                    pass
 
         return records
 
@@ -105,7 +107,8 @@ class DataFrameDtypeConversion(object):
         """ converts columns of pd Timestamps (np.datetime64) to strings
         """
         for col,dformat in col_mapping.items():
-            df[k] = df[k].dt.strftime(dformat)
+            if str(df[col].dtype) == 'datetime64[ns]': # assure that the date column isn't already a string
+                df[col] = df[col].dt.strftime(dformat)
         return df
 
 

--- a/binx/utils.py
+++ b/binx/utils.py
@@ -12,16 +12,16 @@ import numpy as np
 import logging
 l = logging.getLogger(__name__)
 
-from pprint import pprint 
+from pprint import pprint
+import datetime
 
 def bfs_shortest_path(graph, start, end):
     """ a generic bfs search algo
     """
     def _bfs_paths(graph, start, end):
         # bfs using a generator. should return shortest path if any for an iteration
-        #pprint('inside bfs: ' +  str(graph))
+
         queue = [(start, [start])]
-        #pprint('queue: ' + str(queue))
         while queue:
             (vertex, path) = queue.pop(0)
             for next_vertex in graph[vertex] - set(path):
@@ -73,6 +73,18 @@ class RecordUtils(object):
         return [dict(zip(column_dict, d)) for d in zip(*column_dict.values())]
 
 
+    def date_to_string(self, col_mapping, records):
+        """converts datetime or date objects to strings
+        """
+        for rec in records:
+            for col,dformat in col_mapping:
+                if isinstance(rec[col], datetime.date)
+                    rec[col] = datetime.datetime.strftime(dformat)
+                else:
+                    rec[col] = datetime.date.strftime(dformat)
+
+        return records
+
 
 
 class DataFrameDtypeConversion(object):
@@ -89,15 +101,13 @@ class DataFrameDtypeConversion(object):
         return df.fillna(value=np.nan)
 
 
-    def end_date_slicer(self, df, start_slice_date, end_slice_date):
-        ''' slices a bema_calc df by its end_date column
-        :PARAMS: start_slice_date, end_slice_date - these should be converted to datetime
-        :RETURNS: a sliced df
-        '''
-        date_filtered_df = df[(df['end_date'] >= start_slice_date) &
-                (df['end_date'] <= end_slice_date)].reset_index(drop=True)
+    def date_to_string(self, col_mapping, df):
+        """ converts columns of pd Timestamps (np.datetime64) to strings
+        """
+        for col,dformat in col_mapping.items():
+            df[k] = df[k].dt.strftime(dformat)
+        return df
 
-        return date_filtered_df
 
     def compare_two_dfs(self, left, right):
         """ returns sorted dicts for more granular comparison of values

--- a/binx/utils.py
+++ b/binx/utils.py
@@ -79,9 +79,9 @@ class RecordUtils(object):
         for rec in records:
             for col,dformat in col_mapping.items():
                 if isinstance(rec[col], datetime.datetime):
-                    rec[col] = datetime.datetime.strftime(dformat)
+                    rec[col] = rec[col].strftime(dformat)
                 elif isinstance(rec[col], datetime.date):
-                    rec[col] = datetime.date.strftime(dformat)
+                    rec[col] = rec[col].strftime(dformat)
                 else: # this means its already in a non-dt format
                     pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     test_suite='nose.collector',
     tests_require=test_requirements,
     url='https://github.com/bsnacks000/binx',
-    version='0.2.0',
+    version='0.2.1',
     zip_safe=False,
 )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -85,14 +85,11 @@ class TestBaseSerializer(unittest.TestCase):
 
 class TestBaseCollection(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        #NOTE monkey patch the class
+    def setUp(self):
+        #tests the load method
         BaseCollection.serializer_class = InternalSerializer
         BaseCollection.internal_class = InternalObject
 
-    def setUp(self):
-        #tests the load method
         self.data = [
             {'bdbid': 1, 'name': 'hi-there'},
             {'bdbid': 2, 'name': 'hi-ho'},
@@ -130,7 +127,6 @@ class TestBaseCollection(unittest.TestCase):
 
         ]
 
-        []
 
     def test_base_collection_correctly_loads_good_data(self):
         base = BaseCollection()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -78,6 +78,11 @@ class TestBaseSerializer(unittest.TestCase):
         self.assertEqual(out['bdbid'], np.dtype('int64'))
         self.assertEqual(out['name'], np.dtype('<U'))
 
+
+    def test_serializer_dateformat_fields(self):
+        self.fail('TODO')
+
+
 class TestBaseCollection(unittest.TestCase):
 
     @classmethod
@@ -228,19 +233,6 @@ class TestBaseCollection(unittest.TestCase):
         base = BaseCollection()
         base.load_data(self.dtype_test_data)
 
-        # df = base.to_dataframe()
-        # correct_dtypes = pd.Series([
-        #     np.dtype('int64'),
-        #     np.dtype('object'),
-        #     np.dtype('float64'),
-        #     np.dtype('datetime64[ns]'),
-        #     np.dtype('datetime64[ns]'),
-        #     np.dtype('bool'),
-        #     np.dtype('object')
-        #     ], index=['id', 'name', 'number', 'date', 'datet', 'tf', 'some_list'])
-            
-        # assert_series_equal(df.dtypes, correct_dtypes, check_names=False)
-
         base2 = BaseCollection()
         base2.load_data(self.dtype_test_data_none)
         df = base2.to_dataframe()
@@ -259,3 +251,7 @@ class TestBaseCollection(unittest.TestCase):
 
         BaseCollection in base.internal.registered_colls
         self.assertTrue(test)
+
+
+    def test_datetime_and_date_objects_get_correctly_parsed_by_load_data(self):
+        self.fail('TODO')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from binx.utils import bfs_shortest_path, ObjUtils, RecordUtils, DataFrameDtypeC
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import numpy as np
-
+from marshmallow import fields
 
 class TestUtils(unittest.TestCase):
 
@@ -96,9 +96,133 @@ class TestUtils(unittest.TestCase):
     def test_dfconv_date_to_string(self):
         self.fail('TODO')
 
+    def test_record_util_date_to_string_SHOULD_BE_RIGHT(self):
+        rec = [
+        {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : np.datetime64("2018-01-25T12:00"), 'd' : 2},
+        {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : np.datetime64("2018-02-25T12:00"), 'd' : 3}
+        ]
+        cols = {#'a': fields.Str(),
+                #'b': fields.Str(),
+                0: {'c': ["%Y-%M-%DT%h:%m"]},
+                1: {'c': ["%Y-%M-%DT%h:%m"]}
+                #'d': fields.Int()
+                }
+        #cols = {'a': [1,2], 'b': [3,4]}
+        result = [
+        {'a' : "stringgg",
+         'b' : "07/25/2018 12:00:00",
+         'c' : "01/25/2018 12:00:00",
+         'd':2},
+        {'a' : "anotherstring!" ,
+         'b' : "10/25/2018 12:00:00",
+         'c' : "02/25/2018 12:00:00",
+         'd' : 3}
+        ]
+        self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
+    # def test_record_util_date_to_string1(self):
+    #     rec = [
+    #     {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : np.datetime64("2018-01-25T12:00"), 'd' : 2},
+    #     {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : np.datetime64("2018-02-25T12:00"), 'd' : 3}
+    #     ]
+    #     cols = {#'a': fields.Str(),
+    #             #'b': fields.Str(),
+    #             'c': fields.DateTime(format="%Y-%M-%DT%h:%m"),
+    #             #'d': fields.Int()
+    #             }
+    #     #cols = {'a': [1,2], 'b': [3,4]}
+    #     result = [
+    #     {'a' : "stringgg",
+    #      'b' : "07/25/2018 12:00:00",
+    #      'c' : "01/25/2018 12:00:00",
+    #      'd':2},
+    #     {'a' : "anotherstring!" ,
+    #      'b' : "10/25/2018 12:00:00",
+    #      'c' : "02/25/2018 12:00:00",
+    #      'd' : 3}
+    #     ]
+    #     self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
+    #
+    # def test_record_util_date_to_string2(self):
+    #     rec = [
+    #     {'a' : "stringgg",
+    #      'b' : "07/25/2018 12:00:00",
+    #      'c' : np.datetime64("2018-01-25T12:00"),
+    #      'd' : 2},
+    #
+    #     {'a' : "anotherstring!" ,
+    #      'b' : "10/25/2018 12:00:00",
+    #      'c' : np.datetime64("2018-02-25T12:00"),
+    #      'd' : 3}
+    #     ]
+    #     cols = {'a': fields.Str(),
+    #             'b': fields.Str(),
+    #             'c': fields.DateTime(format="%Y-%M-%DT%h:%m"),
+    #             'd': fields.Int()
+    #             }
+    #     #cols = {'a': [1,2], 'b': [3,4]}
+    #     result = [
+    #     {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : "01/25/2018 12:00:00", 'd':2},
+    #     {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : "02/25/2018 12:00:00", 'd':3}
+    #     ]
+    #     self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
+    #
+    def test_record_util_date_to_string3(self):
+        rec = [
+        {'a' : "stringgg",
+         'b' : "07/25/2018 12:00:00",
+         'c' : np.datetime64("2018-01-25T12:00"),
+         'd' : 2},
 
-    def test_record_util_date_to_string(self):
-        self.fail('TODO')
+        {'a' : "anotherstring!" ,
+         'b' : "10/25/2018 12:00:00",
+         'c' : np.datetime64("2018-02-25T12:00"),
+         'd' : 3}
+        ]
+        cols = {#'a': fields.Str(),
+                #'b': fields.Str(),
+                'c': "%Y-%M-%DT%h:%m",
+                #'d': fields.Int()
+                }
+        #cols = {'a': [1,2], 'b': [3,4]}
+        result = [
+        {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : "01/25/2018 12:00:00", 'd':2},
+        {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : "02/25/2018 12:00:00", 'd':3}
+        ]
+        self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
+    def test_record_util_date_to_string3(self):
 
+        class TestSerializer(BaseSerializer):
+            a = fields.Str()
+            b = fields.Str()
+            c = fields.DateTime(format="%Y-%M-%DT%h:%m")
+            d = fields.Int()
 
+            cols = {#'a': fields.Str(),
+                    #'b': fields.Str(),
+                    'c': "%Y-%M-%DT%h:%m",
+                    #'d': fields.Int()
+                    }
+        rec = [
+        {'a' : "stringgg",
+         'b' : "07/25/2018 12:00:00",
+         'c' : np.datetime64("2018-01-25T12:00"),
+         'd' : 2},
 
+        {'a' : "anotherstring!" ,
+         'b' : "10/25/2018 12:00:00",
+         'c' : np.datetime64("2018-02-25T12:00"),
+         'd' : 3}
+        ]
+        cols = {#'a': fields.Str(),
+                #'b': fields.Str(),
+                'c': "%Y-%M-%DT%h:%m",
+                #'d': fields.Int()
+                }
+        #cols = {'a': [1,2], 'b': [3,4]}
+        result = [
+        {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : "01/25/2018 12:00:00", 'd':2},
+        {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : "02/25/2018 12:00:00", 'd':3}
+        ]
+        self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
+
+#unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
 """ tests for the utils module
 """
 
-import unittest 
-from binx.utils import bfs_shortest_path, ObjUtils, RecordUtils, DataFrameDtypeConversion 
+import unittest
+from binx.utils import bfs_shortest_path, ObjUtils, RecordUtils, DataFrameDtypeConversion
 
 import pandas as pd
 from pandas.testing import assert_frame_equal
-import numpy as np 
+import numpy as np
 
 
 class TestUtils(unittest.TestCase):
@@ -40,7 +40,7 @@ class TestUtils(unittest.TestCase):
         ]
         r = self.recordutils.columns_to_records(cols)
         self.assertEqual(test, r)
-    
+
     def test_record_utils_records_to_columns(self):
         records = [
             {'a':1, 'b':3},
@@ -53,7 +53,7 @@ class TestUtils(unittest.TestCase):
 
     def test_obj_util_get_fully_qualified_path(self):
         class Test:
-            pass 
+            pass
         t = Test()
         clspath = self.objutils.get_fully_qualified_path(t)
         self.assertEqual('tests.test_utils.Test', clspath)
@@ -70,10 +70,10 @@ class TestUtils(unittest.TestCase):
         df = pd.DataFrame({'a':[1, None], 'b':[2,None]})
         test = pd.DataFrame({'a':[1, np.nan], 'b':[2,np.nan]})
 
-        d = self.dfconv.df_none_to_nan(df) 
+        d = self.dfconv.df_none_to_nan(df)
         assert_frame_equal(test, d)
 
-    
+
     def test_bfs_shortest_path(self):
 
         graph = {
@@ -91,3 +91,14 @@ class TestUtils(unittest.TestCase):
         test = ['A', 'B', 'D']
         result = bfs_shortest_path(graph, 'A', 'D')
         self.assertEqual(result, test)
+
+
+    def test_dfconv_date_to_string(self):
+        self.fail('TODO')
+
+
+    def test_record_util_date_to_string(self):
+        self.fail('TODO')
+
+
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,8 @@ from pandas.testing import assert_frame_equal
 import numpy as np
 from marshmallow import fields
 
+from datetime import datetime, date
+
 class TestUtils(unittest.TestCase):
 
     def setUp(self):
@@ -66,6 +68,7 @@ class TestUtils(unittest.TestCase):
         d = self.dfconv.df_nan_to_none(df)
         assert_frame_equal(d, test, check_dtype=False)
 
+
     def test_dfconv_df_none_to_nan(self):
         df = pd.DataFrame({'a':[1, None], 'b':[2,None]})
         test = pd.DataFrame({'a':[1, np.nan], 'b':[2,np.nan]})
@@ -94,135 +97,33 @@ class TestUtils(unittest.TestCase):
 
 
     def test_dfconv_date_to_string(self):
-        self.fail('TODO')
 
-    def test_record_util_date_to_string_SHOULD_BE_RIGHT(self):
-        rec = [
-        {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : np.datetime64("2018-01-25T12:00"), 'd' : 2},
-        {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : np.datetime64("2018-02-25T12:00"), 'd' : 3}
+        # note that only datetime objects get converted to pd.Timestamps.
+        # datetime.date objects are loaded in as type object not type pd.TimeStamp
+        records = [
+            {'a': 1, 'b': datetime(2017,5,4, 10, 10, 10), 'c': datetime(2017,5,4)},
+            {'a': 2, 'b': datetime(2017,6,4, 10, 10, 10), 'c': datetime(2018,5,4)},
+            {'a': 3, 'b': datetime(2017,7,4, 10, 10, 10), 'c': datetime(2019,5,4)},
         ]
-        cols = {#'a': fields.Str(),
-                #'b': fields.Str(),
-                0: {'c': ["%Y-%M-%DT%h:%m"]},
-                1: {'c': ["%Y-%M-%DT%h:%m"]}
-                #'d': fields.Int()
-                }
-        #cols = {'a': [1,2], 'b': [3,4]}
-        result = [
-        {'a' : "stringgg",
-         'b' : "07/25/2018 12:00:00",
-         'c' : "01/25/2018 12:00:00",
-         'd':2},
-        {'a' : "anotherstring!" ,
-         'b' : "10/25/2018 12:00:00",
-         'c' : "02/25/2018 12:00:00",
-         'd' : 3}
-        ]
-        self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
-    # def test_record_util_date_to_string1(self):
-    #     rec = [
-    #     {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : np.datetime64("2018-01-25T12:00"), 'd' : 2},
-    #     {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : np.datetime64("2018-02-25T12:00"), 'd' : 3}
-    #     ]
-    #     cols = {#'a': fields.Str(),
-    #             #'b': fields.Str(),
-    #             'c': fields.DateTime(format="%Y-%M-%DT%h:%m"),
-    #             #'d': fields.Int()
-    #             }
-    #     #cols = {'a': [1,2], 'b': [3,4]}
-    #     result = [
-    #     {'a' : "stringgg",
-    #      'b' : "07/25/2018 12:00:00",
-    #      'c' : "01/25/2018 12:00:00",
-    #      'd':2},
-    #     {'a' : "anotherstring!" ,
-    #      'b' : "10/25/2018 12:00:00",
-    #      'c' : "02/25/2018 12:00:00",
-    #      'd' : 3}
-    #     ]
-    #     self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
-    #
-    # def test_record_util_date_to_string2(self):
-    #     rec = [
-    #     {'a' : "stringgg",
-    #      'b' : "07/25/2018 12:00:00",
-    #      'c' : np.datetime64("2018-01-25T12:00"),
-    #      'd' : 2},
-    #
-    #     {'a' : "anotherstring!" ,
-    #      'b' : "10/25/2018 12:00:00",
-    #      'c' : np.datetime64("2018-02-25T12:00"),
-    #      'd' : 3}
-    #     ]
-    #     cols = {'a': fields.Str(),
-    #             'b': fields.Str(),
-    #             'c': fields.DateTime(format="%Y-%M-%DT%h:%m"),
-    #             'd': fields.Int()
-    #             }
-    #     #cols = {'a': [1,2], 'b': [3,4]}
-    #     result = [
-    #     {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : "01/25/2018 12:00:00", 'd':2},
-    #     {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : "02/25/2018 12:00:00", 'd':3}
-    #     ]
-    #     self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
-    #
-    def test_record_util_date_to_string3(self):
-        rec = [
-        {'a' : "stringgg",
-         'b' : "07/25/2018 12:00:00",
-         'c' : np.datetime64("2018-01-25T12:00"),
-         'd' : 2},
+        col_mapping = {'b': '%Y-%m-%d %H:%M:%S', 'c': '%Y-%m-%d'}
 
-        {'a' : "anotherstring!" ,
-         'b' : "10/25/2018 12:00:00",
-         'c' : np.datetime64("2018-02-25T12:00"),
-         'd' : 3}
-        ]
-        cols = {#'a': fields.Str(),
-                #'b': fields.Str(),
-                'c': "%Y-%M-%DT%h:%m",
-                #'d': fields.Int()
-                }
-        #cols = {'a': [1,2], 'b': [3,4]}
-        result = [
-        {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : "01/25/2018 12:00:00", 'd':2},
-        {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : "02/25/2018 12:00:00", 'd':3}
-        ]
-        self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
-    def test_record_util_date_to_string3(self):
+        df = pd.DataFrame.from_records(records)
+        test_recs = self.dfconv.date_to_string(col_mapping, df)
 
-        class TestSerializer(BaseSerializer):
-            a = fields.Str()
-            b = fields.Str()
-            c = fields.DateTime(format="%Y-%M-%DT%h:%m")
-            d = fields.Int()
+        self.assertEqual(str(test_recs['b'].dtype), 'object')
+        self.assertEqual(str(test_recs['c'].dtype), 'object')
 
-            cols = {#'a': fields.Str(),
-                    #'b': fields.Str(),
-                    'c': "%Y-%M-%DT%h:%m",
-                    #'d': fields.Int()
-                    }
-        rec = [
-        {'a' : "stringgg",
-         'b' : "07/25/2018 12:00:00",
-         'c' : np.datetime64("2018-01-25T12:00"),
-         'd' : 2},
+    def test_record_util_date_to_string(self):
 
-        {'a' : "anotherstring!" ,
-         'b' : "10/25/2018 12:00:00",
-         'c' : np.datetime64("2018-02-25T12:00"),
-         'd' : 3}
+        records = [
+            {'a': 1, 'b': datetime(2017,5,4, 10, 10, 10), 'c': date(2017,5,4)},
         ]
-        cols = {#'a': fields.Str(),
-                #'b': fields.Str(),
-                'c': "%Y-%M-%DT%h:%m",
-                #'d': fields.Int()
-                }
-        #cols = {'a': [1,2], 'b': [3,4]}
-        result = [
-        {'a' : "stringgg", 'b' : "07/25/2018 12:00:00", 'c' : "01/25/2018 12:00:00", 'd':2},
-        {'a' : "anotherstring!" , 'b' : "10/25/2018 12:00:00", 'c' : "02/25/2018 12:00:00", 'd':3}
-        ]
-        self.assertEqual(self.recordutils.date_to_string(cols,rec),result)
 
-#unittest.main()
+        col_mapping = {'b': '%Y-%m-%d %H:%M:%S', 'c': '%Y-%m-%d'}
+        test = [{'a': 1, 'b': '2017-05-04 10:10:10', 'c': '2017-05-04'}]
+
+        test_recs = self.recordutils.date_to_string(col_mapping, records)
+
+        self.assertListEqual(test, test_recs)
+
+


### PR DESCRIPTION
Added methods in utils to handle loading datetime, date and TimeStamp objects. 
Serializers should be able to introspect their own fields and pick out column names and datetime formats. These are stored on the instance and used to lookup mappings for loading 