### PR TITLE
Registry error to Warning

### DIFF
--- a/binx/registry.py
+++ b/binx/registry.py
@@ -17,10 +17,16 @@ def register_collection(cls):
     fullpath = cls.__module__ + '.' + cls.__name__
 
     if fullpath in _collection_registry: # if the fullpath is already
-        #raise RegistryError('The classname {} has already been registered. Create a different name for your collection'.format(fullpath))
+        # if registered_adapters or adaptable_from already have values we should raise here
+        # this should be enough to ensure the adapter chain won't be compromised by accident
+        adapters = _collection_registry[fullpath][1]['registered_adapters']
+        from_colls = _collection_registry[fullpath][1]['adaptable_from']
+
+        if len(adapters) > 0 or len(from_colls) > 0:
+            raise RegistryError('The name {} has already been registered in the adapter chain and cannot be overridden'.format(fullpath))
 
         _collection_registry[fullpath][0] = cls
-        warnings.warn("The reference to {} has been overridden in the registry. This might potentially cause issues in any adapter chain where this class was referenced.".format(fullpath))
+        warnings.warn("The reference to {} has been overridden in the registry.".format(fullpath))
 
     else:
         # you must do the lookup by fullpath

--- a/binx/registry.py
+++ b/binx/registry.py
@@ -5,6 +5,7 @@ are created by the user and registered at runtime.
 
 from .exceptions import RegistryError
 from .utils import bfs_shortest_path
+import warnings
 
 _collection_registry = {}
 
@@ -16,16 +17,19 @@ def register_collection(cls):
     fullpath = cls.__module__ + '.' + cls.__name__
 
     if fullpath in _collection_registry: # if the fullpath is already
-        raise RegistryError('The classname {} has already been registered. Create a different name for your collection'.format(fullpath))
+        #raise RegistryError('The classname {} has already been registered. Create a different name for your collection'.format(fullpath))
 
-    # you must do the lookup by fullpath
-    _collection_registry[fullpath] = (cls, {
-        'serializer_class': cls.serializer_class,
-        'internal_class': cls.internal_class,
-        'registered_adapters': set(),  #NOTE these are the classes registered adapters
-        'adaptable_from': set()   #NOTE these are other collection objects a coll can be adapted from
-    })
-    #pprint(_collection_registry)
+        _collection_registry[fullpath][0] = cls
+        warnings.warn("The reference to {} has been overridden in the registry. This might potentially cause issues in any adapter chain where this class was referenced.".format(fullpath))
+
+    else:
+        # you must do the lookup by fullpath
+        _collection_registry[fullpath] = [cls, {
+            'serializer_class': cls.serializer_class,
+            'internal_class': cls.internal_class,
+            'registered_adapters': set(),  #NOTE these are the classes registered adapters
+            'adaptable_from': set()   #NOTE these are other collection objects a coll can be adapted from
+        }]
 
 
 def get_class_from_collection_registry(classname):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -219,19 +219,3 @@ class TestAdapterCollectionIntegration(unittest.TestCase):
 
         self.assertEqual(test_data, test_c_coll.data)
         self.assertEqual(test_context, context)
-
-    def test_adapter_accumulates_collections(self):
-        # test for issue 10 -- accumulate feature
-
-        test_a_coll = self.TestAACollection()
-        test_a_coll.load_data([{'a': 41}])
-
-        test_c_coll, context = self.TestCCCollection.adapt(test_a_coll, accumulate=True, foo='bar')
-
-        # accumulate True means BB should be in there
-        self.assertIn('TestBBCollection', context.keys())
-        self.assertIsInstance(context['TestBBCollection'], self.TestBBCollection)
-
-        self.assertNotIn('TestCCCollection',context.keys())
-        self.assertNotIn('TestAACollection',context.keys())
-

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -34,16 +34,34 @@ class TestRegistry(unittest.TestCase):
             obj = get_class_from_collection_registry('SomeClass')
 
 
-    def test_registry_raises_if_two_classes_have_same_name(self):
+    # def test_registry_raises_if_two_classes_have_same_name(self):
+        # removed based on issue 1
 
-        with self.assertRaises(RegistryError):
+    #     with self.assertRaises(RegistryError):
 
-            # NOTE user  cannot declare two classes in the same module
-            class TestBaseA(BaseCollection):
-                pass
+    #         # NOTE user  cannot declare two classes in the same module
+    #         class TestBaseA(BaseCollection):
+    #             pass
 
-            class TestBaseA(BaseCollection):
-                pass
+    #         class TestBaseA(BaseCollection):
+    #             pass
+
+    def test_registry_warns_and_replaces_ref_if_given_same_path(self):
+
+        with self.assertWarns(UserWarning):
+            class TestBaseReplaceMe(BaseCollection):
+                a = 1
+
+            class TestBaseReplaceMe(BaseCollection):
+                a = 42
+
+            module = TestBaseReplaceMe.__module__
+            clsname = TestBaseReplaceMe.__name__
+
+            TestClass = get_class_from_collection_registry('.'.join([module, clsname]))
+
+            self.assertEqual(42, TestClass[0].a)
+
 
     def test_collection_registry(self):
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -34,17 +34,27 @@ class TestRegistry(unittest.TestCase):
             obj = get_class_from_collection_registry('SomeClass')
 
 
-    # def test_registry_raises_if_two_classes_have_same_name(self):
-        # removed based on issue 1
+    def test_registry_override_raises_registry_error_if_has_adaptable_collections(self):
 
-    #     with self.assertRaises(RegistryError):
+        class TestBaseA(BaseCollection):
+            pass
 
-    #         # NOTE user  cannot declare two classes in the same module
-    #         class TestBaseA(BaseCollection):
-    #             pass
+        register_adaptable_collection(TestBaseA.get_fully_qualified_class_path(), 'something')
+        with self.assertRaises(RegistryError):
+            class TestBaseA(BaseCollection):
+                pass
 
-    #         class TestBaseA(BaseCollection):
-    #             pass
+
+    def test_registry_override_raises_registry_error_if_has_registered_adapters(self):
+
+        class TestBaseAA(BaseCollection):
+            pass
+
+        register_adapter_to_collection(TestBaseAA.get_fully_qualified_class_path(), 'something')
+        with self.assertRaises(RegistryError):
+            class TestBaseAA(BaseCollection):
+                pass
+
 
     def test_registry_warns_and_replaces_ref_if_given_same_path(self):
 


### PR DESCRIPTION
Changed the behavior of the registry to issue a UserWarning and replace the reference to the class in the registry if given an identical class path name.

