### PR TITLE
Make adapter classes pluggable issue11

### DIFF
--- a/binx/collection.py
+++ b/binx/collection.py
@@ -325,10 +325,7 @@ class BaseCollection(AbstractCollection):
 
     def _clean_records(self, records):
         formatfields = self.serializer.dateformat_fields
-
         util = RecordUtils()
-        #TODO should check nans here but need a faster algo
-
         if len(formatfields) > 0:
             records = util.date_to_string(formatfields, records)
 

--- a/binx/exceptions.py
+++ b/binx/exceptions.py
@@ -40,3 +40,8 @@ class AdapterCollectionResultError(BinxError):
 class AdapterChainError(BinxError):
     """ thrown if a input collection cannot be found on the adapter chain for a Collection
     """
+
+
+class AdapterFunctionError(BinxError, ValueError):
+    """ thrown if a 2-tuple is not returned from a pluggable adapter function.
+    """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author="bsnacks000",
     author_email='bsnacks000@gmail.com',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -8,7 +8,7 @@ from binx.collection import BaseCollection, BaseSerializer, CollectionBuilder
 from binx.adapter import AdapterOutputContainer, AbstractAdapter, register_adapter
 from marshmallow import fields
 
-import binx
+import binx.collection
 from binx.registry import _make_cc_graph, adapter_path
 from binx.utils import bfs_shortest_path
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -8,6 +8,7 @@ from binx.collection import BaseCollection, BaseSerializer, CollectionBuilder
 from binx.adapter import AdapterOutputContainer, AbstractAdapter, register_adapter
 from marshmallow import fields
 
+import binx
 from binx.registry import _make_cc_graph, adapter_path
 from binx.utils import bfs_shortest_path
 
@@ -219,3 +220,58 @@ class TestAdapterCollectionIntegration(unittest.TestCase):
 
         self.assertEqual(test_data, test_c_coll.data)
         self.assertEqual(test_context, context)
+
+
+    def test_accumulate_true_for_c_adapts_a(self):
+
+        test_a_coll = self.TestAACollection()
+        test_a_coll.load_data([{'a': 41}])
+
+        test_c_coll, context = self.TestCCCollection.adapt(test_a_coll, accumulate=True, foo='bar')
+        #print(test_c_coll.data, context)
+        test_data = [{'c': 43, 'b': 42, 'a': 41}]
+        test_context = {'foo': 'bar', 'something_else': 'mups', 'other_context_var': 'tup', 'context_var': 'hep', 'some_thing': 'zups'}
+
+        self.assertEqual(test_data, test_c_coll.data)
+        self.assertIn('TestBBCollection', context)  # check that we have the intermediate collection in the final context
+        self.assertIsInstance(context['TestBBCollection'], binx.collection.Collection)
+        for k,v in context:
+            if k != 'TestBBCollection':
+                self.assertEqual(test_context[k], context[k])
+
+
+class TestPluggableAdapter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+
+    def setUp(self):
+        pass
+
+
+    def test_pluggable_adapter_check_calc(self):
+        self.fail('todo')
+
+
+    def test_pluggable_adapter_creates_expected_result(self):
+        self.fail('todo')
+
+
+    def test_pluggable_adapter_works_with_returned_context(self):
+        self.fail('todo')
+
+
+    def test_pluggable_adapter_works_without_returned_context(self):
+        self.fail('todo')
+
+
+
+class TestPluggableAdapterIntegration(unittest.TestCase):
+
+    def test_pluggable_adapter_works_with_longer_adapter_chain(self):
+        self.fail('todo')
+
+
+

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -5,7 +5,7 @@ import unittest
 import os
 
 from binx.collection import BaseCollection, BaseSerializer, CollectionBuilder
-from binx.adapter import AdapterOutputContainer, AbstractAdapter, register_adapter
+from binx.adapter import AdapterOutputContainer, AbstractAdapter, register_adapter, PluggableAdapter
 from marshmallow import fields
 
 import binx.collection
@@ -13,6 +13,8 @@ from binx.registry import _make_cc_graph, adapter_path
 from binx.utils import bfs_shortest_path
 
 from pprint import pprint
+
+from binx.exceptions import AdapterFunctionError
 
 class TestASerializer(BaseSerializer):
     a = fields.Integer()
@@ -234,44 +236,185 @@ class TestAdapterCollectionIntegration(unittest.TestCase):
 
         self.assertEqual(test_data, test_c_coll.data)
         self.assertIn('TestBBCollection', context)  # check that we have the intermediate collection in the final context
-        self.assertIsInstance(context['TestBBCollection'], binx.collection.Collection)
-        for k,v in context:
+        self.assertIsInstance(context['TestBBCollection'], binx.collection.BaseCollection)
+        for k,v in context.items():
             if k != 'TestBBCollection':
                 self.assertEqual(test_context[k], context[k])
 
 
 class TestPluggableAdapter(unittest.TestCase):
 
+    # NOTE includes integration tests with collections
+
     @classmethod
     def setUpClass(cls):
-        pass
+        builder = CollectionBuilder('TestPluggableA')
+        cls.TestPluggableACollection = builder.build(TestASerializer)
+
+        builder.name = 'TestPluggableB'
+        cls.TestPluggableBCollection = builder.build(TestBSerializer)
+
+        builder.name = 'TestPluggableC'
+        cls.TestPluggableCCollection = builder.build(TestCSerializer)
+
+
+
+        class PluggableAToBAdapter(PluggableAdapter):
+            from_collection_class = cls.TestPluggableACollection
+            target_collection_class = cls.TestPluggableBCollection
+            calc = adapt_a_to_b
+
+
+        class PluggableBToCAdapter(PluggableAdapter):
+            from_collection_class = cls.TestPluggableBCollection
+            target_collection_class = cls.TestPluggableCCollection
+            calc = adapt_b_to_c
+
+
+        cls.PluggableAToBAdapter = PluggableAToBAdapter
+        register_adapter(cls.PluggableAToBAdapter)
+
+        cls.PluggableBToCAdapter = PluggableBToCAdapter
+        register_adapter(cls.PluggableBToCAdapter)
 
 
     def setUp(self):
-        pass
+        self.PluggableAToBAdapter = self.__class__.PluggableAToBAdapter
+        self.TestPluggableACollection = self.__class__.TestPluggableACollection
+        self.TestPluggableBCollection = self.__class__.TestPluggableBCollection
+        self.TestPluggableCCollection = self.__class__.TestPluggableCCollection
 
 
-    def test_pluggable_adapter_check_calc(self):
-        self.fail('todo')
+    def tearDown(self):
+        self.PluggableAToBAdapter = None
+        self.TestPluggableACollection = None
+        self.TestPluggableBCollection = None
+        self.TestPluggableCCollection = None
+
+
+    def test_pluggable_adapter_check_calc_raises_TypeError_if_not_callable(self):
+
+        with self.assertRaises(TypeError):
+            PluggableAdapter._check_calc(None, 42)
+
+
+    def test_pluggable_adapter_check_calc_raises_AssertionError_on_bad_signature(self):
+
+        def _func(blah, **things):
+            return
+
+        with self.assertRaises(AssertionError):
+            PluggableAdapter._check_calc(None, _func)
+
+
+    def test_pluggable_adapter_check_calc_raises_AssertionError_on_extra_args(self):
+
+        def _func(collection, thing, duh=42, **context):
+            return
+
+        with self.assertRaises(AssertionError):
+            PluggableAdapter._check_calc(None, _func)
+
+
+    def test_pluggable_adapter_check_calc_raises_AssertionError_on_no_context_kwargs(self):
+
+        def _func(collection, context):
+            return
+
+        with self.assertRaises(AssertionError):
+            PluggableAdapter._check_calc(None, _func)
+
+
+    def test_pluggable_adapter_check_calc_passes_on_valid_signature(self):
+
+        def _func(collection, **context):
+            return
+        self.assertTrue(PluggableAdapter._check_calc(None, _func))
 
 
     def test_pluggable_adapter_creates_expected_result(self):
-        self.fail('todo')
+        test_a_coll = self.TestPluggableACollection()
+        test_a_coll.load_data([{'a': 41}])
+
+        test_c_coll, context = self.TestPluggableCCollection.adapt(test_a_coll, foo='bar')
+        #print(test_c_coll.data, context)
+        test_data = [{'c': 43, 'b': 42, 'a': 41}]
+        test_context = {'foo': 'bar', 'something_else': 'mups', 'other_context_var': 'tup', 'context_var': 'hep', 'some_thing': 'zups'}
+
+        self.assertEqual(test_data, test_c_coll.data)
+        self.assertEqual(test_context, context)
 
 
-    def test_pluggable_adapter_works_with_returned_context(self):
-        self.fail('todo')
+    def test_pluggable_adpater_accumulates_collections(self):
+
+        test_a_coll = self.TestPluggableACollection()
+        test_a_coll.load_data([{'a': 41}])
+
+        test_c_coll, context = self.TestPluggableCCollection.adapt(test_a_coll, accumulate=True, foo='bar')
+        #print(test_c_coll.data, context)
+        test_data = [{'c': 43, 'b': 42, 'a': 41}]
+        test_context = {'foo': 'bar', 'something_else': 'mups', 'other_context_var': 'tup', 'context_var': 'hep', 'some_thing': 'zups'}
+
+        self.assertEqual(test_data, test_c_coll.data)
+        self.assertIn('TestPluggableBCollection', context)  # check that we have the intermediate collection in the final context
+        self.assertIsInstance(context['TestPluggableBCollection'], binx.collection.BaseCollection)
+        for k,v in context.items():
+            if k != 'TestPluggableBCollection':
+                self.assertEqual(test_context[k], context[k])
 
 
-    def test_pluggable_adapter_works_without_returned_context(self):
-        self.fail('todo')
+    def test_pluggable_adapter_throws_AdapterFunctionError_without_returned_context(self):
+
+        # This test assures you can create an adapter function that does not manipulate the context
+        # dict and it will return the same.
+
+        self.PluggableBToCAdapter.calc = adapt_b_to_c_no_context
+
+        test_a_coll = self.TestPluggableACollection()
+        test_a_coll.load_data([{'a': 41}])
+
+        adapter = self.PluggableBToCAdapter()
+        with self.assertRaises(AdapterFunctionError):
+            adapter.adapt(test_a_coll)
+
+        self.PluggableBToCAdapter.calc = adapt_b_to_c
+
+
+    def test_pluggable_adapter_throws_AdapterFunctionError_on_bad_context(self):
+
+        self.PluggableBToCAdapter.calc = adapt_b_to_c_context_bad
+
+        test_a_coll = self.TestPluggableACollection()
+        test_a_coll.load_data([{'a': 41}])
+
+        adapter = self.PluggableBToCAdapter()
+        with self.assertRaises(AdapterFunctionError):
+            adapter.adapt(test_a_coll)
+
+        self.PluggableBToCAdapter.calc = adapt_b_to_c
 
 
 
-class TestPluggableAdapterIntegration(unittest.TestCase):
+# for testing pluggable adapter
+def adapt_a_to_b(collection, **context):
+            df = collection.to_dataframe()
+            df['b'] = 42  # add a column b with some dataframe here
+            return df, {'context_var':'hep', 'other_context_var': 'tup'}
 
-    def test_pluggable_adapter_works_with_longer_adapter_chain(self):
-        self.fail('todo')
+def adapt_b_to_c(collection, **context):
+    df = collection.to_dataframe()
+    df['c'] = 43  # add a column c with some dataframe here
+    return df, dict(something_else='mups', some_thing='zups')
 
 
+def adapt_b_to_c_no_context(collection, **context):
+    df = collection.to_dataframe()
+    df['c'] = 43  # add a column c with some dataframe here
+    return df
+
+
+def adapt_b_to_c_context_bad(collection, **context):
+    df = collection.to_dataframe()
+    df['c'] = 43  # add a column c with some dataframe here
+    return df, 'blah'
 


### PR DESCRIPTION
New feature for issue #11 
* PluggableAdapter class - can bind a static method and check signature of an adapter class

```python

class MyPluggableAdapter(PluggableAdapter):
    target_collection_class = MyTargetCollection 
    from_collection_class = MyFromCollection 
    calc = my_calc_method 

```
This works identically to directly subclassing AbstractAdapter and implementing the ```adapt``` method

