### PR TITLE
pinning to marhsmallow==3.1.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ binx
         :target: https://binx.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-:version: 0.4.0
+:version: 0.4.1
 
 
 ``binx`` is a small Python framework for application data modeling and transformation. It's API relies heavily on `marshmallow

--- a/binx/__init__.py
+++ b/binx/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """bsnacks000"""
 __email__ = 'bsnacks000@gmail.com'
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 
 from .collection import BaseCollection, BaseSerializer, InternalObject

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
-
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['pandas', 'marshmallow>=3.0' ]
+requirements = ['pandas', 'marshmallow==3.1.1' ]
 
 setup_requirements = [ ]
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite='nose.collector',
     tests_require=test_requirements,
     url='https://github.com/bsnacks000/binx',
-    version='0.4.0',
+    version='0.4.1',
     zip_safe=False,
 )


### PR DESCRIPTION
fixes an issue with the public method ``.fields`` being removed. 

I am creating a patch release for this that pins marhsmallow to 3.1.1 until I have time to fix it going into future releases