### PR TITLE
Fix marshmallow 3.2 error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -61,3 +61,14 @@ to that allows loading data and setting ma configuration directly from Collectio
 * private api changes to Serializer and Collection classes.
 * data can now be loaded via the Collection constructor.
 * kwargs can be passed to the underlying ma schema at runtime.
+
+
+0.4.1 (2019-09-23)
+------------------
+A patch that pins the library to marshmallow-v3.1.1
+
+
+0.4.2 (2019-10-27)
+------------------
+Bugfix that fixes the dependency in the previous patch. This version is compatible with marshmallow>=3.1.1.
+Also assures pandas>=0.23 in setup.py

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ binx
         :target: https://binx.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-:version: 0.4.1
+:version: 0.4.2
 
 
 ``binx`` is a small Python framework for application data modeling and transformation. It's API relies heavily on `marshmallow

--- a/binx/__init__.py
+++ b/binx/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """bsnacks000"""
 __email__ = 'bsnacks000@gmail.com'
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 
 from .collection import BaseCollection, BaseSerializer, InternalObject

--- a/binx/collection.py
+++ b/binx/collection.py
@@ -56,16 +56,12 @@ class BaseSerializer(Schema):
 
     }
 
-
     def __init__(self, *args, **kwargs):
-
         if 'internal' in kwargs:
             self._InternalClass = kwargs.pop('internal')
         else:
             raise InternalNotDefinedError('An InternalObject class must be instantiated with this Collection')
-
-        super(Schema, self).__init__(*args, **kwargs)
-
+        super().__init__(*args, **kwargs)
         self.dateformat_fields = self._set_dateformat_fields()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.4.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['pandas', 'marshmallow>=3' ]
+requirements = ['pandas>=0.23', 'marshmallow>=3.2' ]
 
 setup_requirements = [ ]
 
-test_requirements = [ 'nose ']
+test_requirements = [ 'nose']
 
 setup(
     author="bsnacks000",

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite='nose.collector',
     tests_require=test_requirements,
     url='https://github.com/bsnacks000/binx',
-    version='0.4.1',
+    version='0.4.2',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['pandas>=0.23', 'marshmallow>=3.2' ]
+requirements = ['pandas>=0.23', 'marshmallow>=3' ]
 
 setup_requirements = [ ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['pandas', 'marshmallow==3.1.1' ]
+requirements = ['pandas', 'marshmallow>=3' ]
 
 setup_requirements = [ ]
 


### PR DESCRIPTION
Fixes a bug in BaseSerializer.__init__ that was causing a breakage with marshmallow v3.2.1